### PR TITLE
Use the drive name and serial info to generate share name.

### DIFF
--- a/scripts/drive.sh
+++ b/scripts/drive.sh
@@ -14,7 +14,8 @@ function attach {
 function create_config {
   DISK=$1
   SHARE_PATH=$2
-  echo "[Shared-${DISK}]
+  SHARE_NAME=$(udevadm info -n /dev/${DISK} | grep ID_SERIAL= | cut -d '=' -f 2)
+  echo "[${SHARE_NAME}]
   path = ${SHARE_PATH}
   valid users = @smbgroup
   guest ok = no


### PR DESCRIPTION
The information from udevadm info is used to generate the
samba share name.  This makes it easier for users to identify
which drives are shared.

Change-type: minor
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>