### PR TITLE
Adds partition name to share name.

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -25,6 +25,8 @@ VOLUME ["/etc", \
     "/run/samba"]
 
 ENV UDEV=on
+ENV CONFIG_DIR=/usr/src/config
+ENV SAMBA_ROOT=/samba
 
 EXPOSE 139 445
 

--- a/scripts/drive.sh
+++ b/scripts/drive.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-# DEFAULT SETTINGS
-export CONFIG_DIR=/usr/src/config
-export SAMBA_ROOT=/samba
 
 function attach {
   DISK=$1
@@ -14,8 +11,8 @@ function attach {
 function create_config {
   DISK=$1
   SHARE_PATH=$2
-  SHARE_NAME=$(udevadm info -n /dev/${DISK} | grep ID_SERIAL= | cut -d '=' -f 2)
-  echo "[${SHARE_NAME}]
+  SHARE_NAME=$(udevadm info -n /dev/${DISK} | grep ID_SERIAL= | cut -d'=' -f2 | cut -d":" -f1)
+  echo "[${DISK}-${SHARE_NAME}]
   path = ${SHARE_PATH}
   valid users = @smbgroup
   guest ok = no

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -10,7 +10,7 @@ function setup_user {
 }
 
 function main {
-  cat config/smb-global.conf > /etc/samba/smb.conf
+  cat ${CONFIG_DIR}/smb-global.conf > /etc/samba/smb.conf
   for DISK in `lsblk -o KNAME | egrep sd[a-z][0-9]`
   do
     drive attach $DISK


### PR DESCRIPTION
This avoids Samba share name conflicts when a single
USB drive has multiple partitions.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>